### PR TITLE
Fix nested repo copy path for cheat detection

### DIFF
--- a/lib/brown_noser/version.rb
+++ b/lib/brown_noser/version.rb
@@ -1,3 +1,3 @@
 module BrownNoser
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/lib/pull_branch_file_extractor.rb
+++ b/lib/pull_branch_file_extractor.rb
@@ -43,7 +43,9 @@ private
     ->(){
       files = `git ls-tree --full-name --name-only -r #{user}/#{branch} | grep '\.h$\\|\.cpp$'`.split("\n")
       copy_files = files.map do |file|
-        copy_file(file, "#{dest_folder}/#{file}").call
+        dest_path = "#{dest_folder}/#{file}"
+        FileUtils.mkdir_p(File.dirname(dest_path))
+        copy_file(file, dest_path).call
       end
       copy_files.join(" && ")
     }


### PR DESCRIPTION
If there were many nested folders in a repo when file extraction happened
deeply nested files were lost due to lack of folder structre to copy into
